### PR TITLE
Fix an issue installing with setup.py

### DIFF
--- a/boddle.py
+++ b/boddle.py
@@ -10,9 +10,6 @@ except ImportError:
   from urllib.parse import urlparse, urlencode
 
 
-__version__ = '0.2.3'
-
-
 class boddle(object):
 
   def __init__(self, params={}, path=None, method=None, headers=None, json=None, url=None, body=None, **extras):

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def long_description():
 
 setup(
   name='boddle',
-  version=__import__('boddle').__version__,
+  version='0.2.3',
   description="A unit testing tool for Python's bottle library.",
   long_description=long_description(),
   author='Derek Anderson',

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,6 @@ setup(
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
   ],
-  install_requires=[],
+  install_requires=['bottle'],
 )
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def long_description():
 
 setup(
   name='boddle',
-  version='0.2.3',
+  version=__import__('boddle').__version__,
   description="A unit testing tool for Python's bottle library.",
   long_description=long_description(),
   author='Derek Anderson',


### PR DESCRIPTION
There is a bootstrapping issue when install boddle if you are installing in a fresh environment. The bottle package needs to be completely install prior to installing boddle.

```
$ pip install -e git+https://github.com/keredson/boddle@master#egg=boddle
Obtaining boddle from git+https://github.com/keredson/boddle@master#egg=boddle
  Updating ./.tox/py27/src/boddle clone (to master)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File ".tox/py27/src/boddle/setup.py", line 16, in <module>
        version=__import__('boddle').__version__,
      File "boddle.py", line 3, in <module>
        import bottle, io
    ImportError: No module named bottle
```