### PR TITLE
throw error if 'environ' in extra arg. remove extra_orig.

### DIFF
--- a/boddle.py
+++ b/boddle.py
@@ -25,7 +25,6 @@ class boddle(object):
 
     environ = {}
     self.extras = extras
-    self.extra_orig = {}
     self.orig_app_reader = bottle.BaseRequest.app
     
     if params is not None:
@@ -72,21 +71,18 @@ class boddle(object):
     self.orig = bottle.request.environ
     bottle.request.environ = self.environ
     for k,v in self.extras.items():
-      if hasattr(bottle.request, k):
-        self.extra_orig[k] = getattr(bottle.request, k)
+      if k == 'environ':
+        raise ValueError('%s cannot be used as an extra argument.' % k)
       setattr(bottle.request, k, v)
     setattr(bottle.BaseRequest, 'app', True)
 
   def __exit__(self,a,b,c):
     bottle.request.environ = self.orig
     for k,v in self.extras.items():
-      if k in self.extra_orig:
-        setattr(bottle.request, k, self.extra_orig[k])
-      else:
-        try:
-          delattr(bottle.request, k)
-        except AttributeError:
-          pass
+      try:
+        delattr(bottle.request, k)
+      except AttributeError:
+        pass
     setattr(bottle.BaseRequest, 'app', self.orig_app_reader)
 
 

--- a/tests.py
+++ b/tests.py
@@ -45,7 +45,12 @@ class TestBoddle(unittest.TestCase):
       with boddle(extra='woot2'):
         self.assertEqual(bottle.request.extra, 'woot2')
     self.assertFalse(hasattr(bottle.request,'extra'))
- 
+
+  def testExtraEnviron(self):
+    with self.assertRaises(ValueError):
+      with boddle(environ='bad'):
+        pass
+
   def testJSON(self):
     with boddle(json={'name':'derek'}):
       self.assertEqual(bottle.request.json['name'], 'derek')


### PR DESCRIPTION
I see the point of having `extra_orig` is when the user passes in extra arguments that contain original request attributes, we temporarily store them in it. We set the values passed in by user when entering the context and change it back to original values when exiting the context. 

But actually, I looked into the latest stable version of bottle (0.12.13), the properties of `bottle.request` are all read only, meaning that we can't actually overwrite them. E.g.: 
```
with boddle(user='hi', forms='hey', files='hello'):
  # bottle.request.user == hi
  # bottle.request.forms != 'hey', it's still the default property!
  # bottle.request.files != 'hello', it's still the default property!
```

In our `boddle.py` we do this to set extra arguments:
```
setattr(bottle.request, k, v)
```

This is how bottle handles extra properties:
```
def __setattr__(self, name, value):
    if name == 'environ': return object.__setattr__(self, name, value)
    self.environ['bottle.request.ext.%s'%name] = value
def __getattr__(self, name):
    ''' Search in self.environ for additional user defined attributes. '''
    try:
        var = self.environ['bottle.request.ext.%s'%name]
        return var.__get__(self) if hasattr(var, '__get__') else var
    except KeyError:
        raise AttributeError('Attribute %r not defined.' % name)
```

First, if a user passes in `environ='test'` as extra argument, it will blow this whole bottle thing up. 
Then, `bottle.request.user` works because the extra property is stored as `bottle.request.ext.user` in the `self.environ` dictionary and upon retrieving, there's no `user` property in `request`, so we go to the dictionary to get it as an extra property. And `files` and `forms` are stored as `bottle.request.ext.files` and `bottle.request.ext.forms` in there. That's how bottle prevents its own properties from being overwritten. 

I don't know if anything else we can do to make it work... this change only fixes the "environ" keyword issue. Not sure what we should do about the other issue. And since original properties can't be overwritten, I removed `extra_orig`. 